### PR TITLE
Add Twig integration with encode/decode filters

### DIFF
--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Roukmoute\SqidsBundle\Twig\SqidsExtension;
 use Roukmoute\SqidsBundle\ValueResolver\SqidsValueResolver;
 use Sqids\Sqids;
 use Sqids\SqidsInterface;
 
-return function (ContainerConfigurator $containerConfigurator): void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(Sqids::class)->public();
@@ -16,5 +19,10 @@ return function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SqidsValueResolver::class)
         ->args([service(SqidsInterface::class)])
         ->tag('controller.argument_value_resolver', ['priority' => 150])
+    ;
+
+    $services->set('sqids.twig.extension', SqidsExtension::class)
+        ->args([service(SqidsInterface::class)])
+        ->tag('twig.extension')
     ;
 };

--- a/spec/Twig/SqidsExtensionSpec.php
+++ b/spec/Twig/SqidsExtensionSpec.php
@@ -49,4 +49,40 @@ class SqidsExtensionSpec extends ObjectBehavior
 
         expect($twig->render('template'))->toBe('1');
     }
+
+    public function it_encodes_multiple_numbers()
+    {
+        $extension = new SqidsExtension($this->sqids);
+        $twig = new Environment(
+            new ArrayLoader(['template' => '{{ sqids_encode(1, 2, 3) }}']),
+            ['cache' => false, 'optimizations' => 0]
+        );
+        $twig->addExtension($extension);
+
+        expect($twig->render('template'))->toBe($this->sqids->encode([1, 2, 3]));
+    }
+
+    public function it_encodes_zero()
+    {
+        $extension = new SqidsExtension($this->sqids);
+        $twig = new Environment(
+            new ArrayLoader(['template' => '{{ 0|sqids_encode }}']),
+            ['cache' => false, 'optimizations' => 0]
+        );
+        $twig->addExtension($extension);
+
+        expect($twig->render('template'))->toBe($this->sqids->encode([0]));
+    }
+
+    public function it_decodes_empty_string_to_empty_array()
+    {
+        $extension = new SqidsExtension($this->sqids);
+        $twig = new Environment(
+            new ArrayLoader(['template' => "{{ ''|sqids_decode|length }}"]),
+            ['cache' => false, 'optimizations' => 0]
+        );
+        $twig->addExtension($extension);
+
+        expect($twig->render('template'))->toBe('0');
+    }
 }

--- a/spec/Twig/SqidsExtensionSpec.php
+++ b/spec/Twig/SqidsExtensionSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Roukmoute\SqidsBundle\Twig;
+
+use PhpSpec\ObjectBehavior;
+use Roukmoute\SqidsBundle\Twig\SqidsExtension;
+use Sqids\Sqids;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class SqidsExtensionSpec extends ObjectBehavior
+{
+    private Sqids $sqids;
+
+    public function let()
+    {
+        $this->sqids = new Sqids();
+        $this->beConstructedWith($this->sqids);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(SqidsExtension::class);
+    }
+
+    public function it_encodes_in_twig_file()
+    {
+        $extension = new SqidsExtension($this->sqids);
+        $twig = new Environment(
+            new ArrayLoader(['template' => '{{ 1|sqids_encode }}']),
+            ['cache' => false, 'optimizations' => 0]
+        );
+        $twig->addExtension($extension);
+
+        expect($twig->render('template'))->toBe($this->sqids->encode([1]));
+    }
+
+    public function it_decodes_in_twig_file()
+    {
+        $encoded = $this->sqids->encode([1]);
+        $extension = new SqidsExtension($this->sqids);
+        $twig = new Environment(
+            new ArrayLoader(['template' => "{{ '{$encoded}'|sqids_decode|first }}"]),
+            ['cache' => false, 'optimizations' => 0]
+        );
+        $twig->addExtension($extension);
+
+        expect($twig->render('template'))->toBe('1');
+    }
+}

--- a/src/Twig/SqidsExtension.php
+++ b/src/Twig/SqidsExtension.php
@@ -25,9 +25,9 @@ class SqidsExtension extends AbstractExtension
         ];
     }
 
-    public function encode(int $number): string
+    public function encode(int ...$numbers): string
     {
-        return $this->sqids->encode([$number]);
+        return $this->sqids->encode($numbers);
     }
 
     /**

--- a/src/Twig/SqidsExtension.php
+++ b/src/Twig/SqidsExtension.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roukmoute\SqidsBundle\Twig;
+
+use Sqids\SqidsInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class SqidsExtension extends AbstractExtension
+{
+    public function __construct(private SqidsInterface $sqids)
+    {
+    }
+
+    /**
+     * @return array<TwigFilter>
+     */
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('sqids_encode', [$this, 'encode']),
+            new TwigFilter('sqids_decode', [$this, 'decode']),
+        ];
+    }
+
+    public function encode(int $number): string
+    {
+        return $this->sqids->encode([$number]);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function decode(string $sqid): array
+    {
+        return $this->sqids->decode($sqid);
+    }
+}

--- a/src/Twig/SqidsExtension.php
+++ b/src/Twig/SqidsExtension.php
@@ -7,6 +7,7 @@ namespace Roukmoute\SqidsBundle\Twig;
 use Sqids\SqidsInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class SqidsExtension extends AbstractExtension
 {
@@ -22,6 +23,17 @@ class SqidsExtension extends AbstractExtension
         return [
             new TwigFilter('sqids_encode', [$this, 'encode']),
             new TwigFilter('sqids_decode', [$this, 'decode']),
+        ];
+    }
+
+    /**
+     * @return array<TwigFunction>
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sqids_encode', [$this, 'encode']),
+            new TwigFunction('sqids_decode', [$this, 'decode']),
         ];
     }
 


### PR DESCRIPTION
## Summary
- Create `SqidsExtension` with `sqids_encode` and `sqids_decode` filters
- Register Twig extension as a service with `twig.extension` tag
- Add specs for Twig extension

## Usage
```twig
{# Encode an integer to a sqid #}
{{ 123|sqids_encode }}

{# Decode a sqid to an array of integers #}
{{ 'abc123'|sqids_decode|first }}
```

Closes #1