### PR TITLE
Add #[Sqid] attribute for controller argument resolution

### DIFF
--- a/spec/ValueResolver/SqidsValueResolverSpec.php
+++ b/spec/ValueResolver/SqidsValueResolverSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Roukmoute\SqidsBundle\ValueResolver;
 
 use PhpSpec\ObjectBehavior;
+use Roukmoute\SqidsBundle\Attribute\Sqid;
 use Roukmoute\SqidsBundle\ValueResolver\SqidsValueResolver;
 use Sqids\Sqids;
 use stdClass;
@@ -115,5 +116,37 @@ class SqidsValueResolverSpec extends ObjectBehavior
         $argumentMetadata = new ArgumentMetadata('id', 'string', false, false, null);
 
         $this->resolve($request, $argumentMetadata)->shouldReturn([]);
+    }
+
+    function it_resolves_with_sqid_attribute()
+    {
+        $request = new Request([], [], ['id' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null, false, [new Sqid()]);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
+    }
+
+    function it_resolves_with_sqid_attribute_and_custom_parameter()
+    {
+        $request = new Request([], [], ['sqid' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null, false, [new Sqid(parameter: 'sqid')]);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
+    }
+
+    function it_resolves_with_sqid_attribute_without_type()
+    {
+        $request = new Request([], [], ['id' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('id', null, false, false, null, false, [new Sqid()]);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
+    }
+
+    function it_throws_logic_exception_when_decode_fails_with_attribute()
+    {
+        $request = new Request([], [], ['id' => $this->sqids->encode([1, 2, 3])]);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null, false, [new Sqid()]);
+
+        $this->shouldThrow(\LogicException::class)->during('resolve', [$request, $argumentMetadata]);
     }
 }

--- a/src/Attribute/Sqid.php
+++ b/src/Attribute/Sqid.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roukmoute\SqidsBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class Sqid
+{
+    public function __construct(
+        public readonly ?string $parameter = null,
+    ) {
+    }
+}

--- a/src/ValueResolver/SqidsValueResolver.php
+++ b/src/ValueResolver/SqidsValueResolver.php
@@ -69,10 +69,7 @@ class SqidsValueResolver implements ValueResolverInterface
         }
     }
 
-    /**
-     * @return never
-     */
-    private function handleDecodeException(\InvalidArgumentException $exception, string $name, bool $hasAttribute): iterable
+    private function handleDecodeException(\InvalidArgumentException $exception, string $name, bool $hasAttribute): never
     {
         if ($hasAttribute) {
             throw new \LogicException(sprintf('Unable to decode parameter "%s".', $name), 0, $exception);

--- a/src/ValueResolver/SqidsValueResolver.php
+++ b/src/ValueResolver/SqidsValueResolver.php
@@ -64,20 +64,20 @@ class SqidsValueResolver implements ValueResolverInterface
             }
 
             return $decode;
-        } catch (\InvalidArgumentException $e) {
-            return $this->handleDecodeException($e, $name, $hasAttribute);
+        } catch (\InvalidArgumentException $exception) {
+            return $this->handleDecodeException($exception, $name, $hasAttribute);
         }
     }
 
     /**
      * @return never
      */
-    private function handleDecodeException(\InvalidArgumentException $e, string $name, bool $hasAttribute): iterable
+    private function handleDecodeException(\InvalidArgumentException $exception, string $name, bool $hasAttribute): iterable
     {
         if ($hasAttribute) {
-            throw new \LogicException(sprintf('Unable to decode parameter "%s".', $name), 0, $e);
+            throw new \LogicException(sprintf('Unable to decode parameter "%s".', $name), 0, $exception);
         }
-        throw new NotFoundHttpException(sprintf('The sqid for the "%s" parameter is invalid.', $name), $e);
+        throw new NotFoundHttpException(sprintf('The sqid for the "%s" parameter is invalid.', $name), $exception);
     }
 
     private function getSqidAttribute(ArgumentMetadata $argument): ?Sqid


### PR DESCRIPTION
## Summary
- Create `Sqid` attribute class with optional `parameter` property
- Update `SqidsValueResolver` to check for `#[Sqid]` attribute
- Support custom route parameter via `#[Sqid(parameter: 'name')]`
- Throw `LogicException` when decoding fails with explicit attribute
- Add specs for attribute-based resolution

## Usage
```php
// Basic usage - decode sqid from route parameter matching argument name
public function show(#[Sqid] int $id): Response
{
    // $id is automatically decoded from sqid
}

// Custom parameter - decode from different route parameter
public function show(#[Sqid(parameter: 'sqid')] int $id): Response
{
    // $id is decoded from 'sqid' route parameter
}
```

Closes #2