### PR TITLE
Add advanced resolver modes (passthrough, auto_convert, prefix, aliases)

### DIFF
--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -17,7 +17,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SqidsInterface::class, Sqids::class);
 
     $services->set(SqidsValueResolver::class)
-        ->args([service(SqidsInterface::class)])
+        ->args([
+            service(SqidsInterface::class),
+            param('sqids.passthrough'),
+            param('sqids.auto_convert'),
+            param('sqids.alphabet'),
+        ])
         ->tag('controller.argument_value_resolver', ['priority' => 150])
     ;
 

--- a/spec/ValueResolver/SqidsValueResolverSpec.php
+++ b/spec/ValueResolver/SqidsValueResolverSpec.php
@@ -203,11 +203,11 @@ class SqidsValueResolverSpec extends ObjectBehavior
 
     function it_skips_when_decode_returns_empty_array(\Sqids\SqidsInterface $mockSqids)
     {
-        $this->beConstructedWith($mockSqids, false, false, Sqids::DEFAULT_ALPHABET);
+        $this->beConstructedWith($mockSqids, false, true, Sqids::DEFAULT_ALPHABET);
 
         $mockSqids->decode('validlooking')->willReturn([]);
 
-        $request = new Request([], [], ['_sqid_id' => 'validlooking']);
+        $request = new Request([], [], ['id' => 'validlooking']);
         $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
 
         $this->resolve($request, $argumentMetadata)->shouldReturn([]);

--- a/spec/ValueResolver/SqidsValueResolverSpec.php
+++ b/spec/ValueResolver/SqidsValueResolverSpec.php
@@ -10,7 +10,6 @@ use stdClass;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SqidsValueResolverSpec extends ObjectBehavior
 {
@@ -19,7 +18,7 @@ class SqidsValueResolverSpec extends ObjectBehavior
     function let()
     {
         $this->sqids = new Sqids();
-        $this->beConstructedWith($this->sqids);
+        $this->beConstructedWith($this->sqids, false, false, Sqids::DEFAULT_ALPHABET);
     }
 
     function it_is_initializable()
@@ -27,96 +26,71 @@ class SqidsValueResolverSpec extends ObjectBehavior
         $this->shouldHaveType(SqidsValueResolver::class);
     }
 
-    function it_fails_to_resolve_non_variadic_argument()
+    // Basic resolution tests (without auto_convert, need explicit attribute or prefix)
+
+    function it_fails_when_no_sqid_source_available()
     {
         $request = new Request([], [], ['foo' => $this->sqids->encode([1])]);
+        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
+    }
+
+    function it_fails_to_resolve_variadic_argument()
+    {
+        $request = new Request([], [], ['_sqid_foo' => $this->sqids->encode([1])]);
         $argumentMetadata = new ArgumentMetadata('foo', 'int', true, false, null);
 
         $this->resolve($request, $argumentMetadata)->shouldReturn([]);
     }
 
-    function it_fails_when_no_attribute_for_argument()
+    // Prefix support (_sqid_)
+
+    function it_resolves_with_sqid_prefix()
     {
-        $request = new Request([], [], []);
-        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
-    }
-
-    function it_fails_when_attribute_not_string()
-    {
-        $request = new Request([], [], ['foo' => ['bar']]);
-        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
-    }
-
-    function it_fails_when_attribute_is_object()
-    {
-        $request = new Request([], [], ['foo' => new stdClass()]);
-        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
-    }
-
-    function it_fails_when_argument_lacks_type()
-    {
-        $request = new Request([], [], ['foo' => $this->sqids->encode([1])]);
-        $argumentMetadata = new ArgumentMetadata('foo', null, false, false, null);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
-    }
-
-    function it_fails_when_argument_type_not_class()
-    {
-        $request = new Request([], [], ['foo' => $this->sqids->encode([1])]);
-        $argumentMetadata = new ArgumentMetadata('foo', 'string', false, false, null);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
-    }
-
-    function it_resolves_sqids_int_argument()
-    {
-        $request = new Request([], [], ['foo' => $this->sqids->encode([1])]);
-        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([1]);
-    }
-
-    function it_resolves_sqids_object_argument(Request $request, ParameterBag $attributes)
-    {
-        $encoded = $this->sqids->encode([1]);
-        $request->attributes = $attributes;
-        $attributes->get('foo')->willReturn($encoded);
-        $argumentMetadata = new ArgumentMetadata('foo', stdClass::class, false, false, null);
-
-        $attributes->set('foo', 1)->shouldBeCalled();
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
-    }
-
-    function it_fails_with_sqid_with_multiple_integers()
-    {
-        $request = new Request([], [], ['id' => $this->sqids->encode([1, 2, 3])]);
+        $request = new Request([], [], ['_sqid_id' => $this->sqids->encode([42])]);
         $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
 
-        $this->shouldThrow(new NotFoundHttpException('The sqid for the "id" parameter is invalid.'))->during('resolve', [$request, $argumentMetadata]);
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
     }
 
-    function it_resolves_with_value_equals_0()
+    function it_throws_when_prefix_sqid_is_invalid()
     {
-        $request = new Request([], [], ['id' => $this->sqids->encode([0])]);
+        $request = new Request([], [], ['_sqid_id' => $this->sqids->encode([1, 2, 3])]);
         $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
 
-        $this->resolve($request, $argumentMetadata)->shouldReturn([0]);
+        $this->shouldThrow(\LogicException::class)->during('resolve', [$request, $argumentMetadata]);
     }
 
-    function it_fails_with_wrong_type_argument()
+    // Alias support (sqid, id)
+
+    function it_resolves_using_sqid_alias()
     {
-        $request = new Request([], [], ['id' => $this->sqids->encode([0])]);
-        $argumentMetadata = new ArgumentMetadata('id', 'string', false, false, null);
+        $request = new Request([], [], ['sqid' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
 
-        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
     }
+
+    function it_resolves_using_id_alias()
+    {
+        $request = new Request([], [], ['id' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
+    }
+
+    function it_prevents_alias_reuse_for_multiple_arguments()
+    {
+        $request = new Request([], [], ['id' => $this->sqids->encode([42])]);
+        $argumentMetadata1 = new ArgumentMetadata('foo', 'int', false, false, null);
+        $argumentMetadata2 = new ArgumentMetadata('bar', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata1)->shouldReturn([42]);
+        $this->resolve($request, $argumentMetadata2)->shouldReturn([]);
+    }
+
+    // Attribute support
 
     function it_resolves_with_sqid_attribute()
     {
@@ -128,16 +102,8 @@ class SqidsValueResolverSpec extends ObjectBehavior
 
     function it_resolves_with_sqid_attribute_and_custom_parameter()
     {
-        $request = new Request([], [], ['sqid' => $this->sqids->encode([42])]);
-        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null, false, [new Sqid(parameter: 'sqid')]);
-
-        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
-    }
-
-    function it_resolves_with_sqid_attribute_without_type()
-    {
-        $request = new Request([], [], ['id' => $this->sqids->encode([42])]);
-        $argumentMetadata = new ArgumentMetadata('id', null, false, false, null, false, [new Sqid()]);
+        $request = new Request([], [], ['custom' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null, false, [new Sqid(parameter: 'custom')]);
 
         $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
     }
@@ -148,5 +114,72 @@ class SqidsValueResolverSpec extends ObjectBehavior
         $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null, false, [new Sqid()]);
 
         $this->shouldThrow(\LogicException::class)->during('resolve', [$request, $argumentMetadata]);
+    }
+
+    // Auto convert mode
+
+    function it_resolves_automatically_when_auto_convert_enabled()
+    {
+        $this->beConstructedWith($this->sqids, false, true, Sqids::DEFAULT_ALPHABET);
+
+        $request = new Request([], [], ['id' => $this->sqids->encode([42])]);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([42]);
+    }
+
+    function it_skips_invalid_characters_when_auto_convert_enabled()
+    {
+        $this->beConstructedWith($this->sqids, false, true, Sqids::DEFAULT_ALPHABET);
+
+        $request = new Request([], [], ['id' => 'invalid-chars!']);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
+    }
+
+    // Passthrough mode
+
+    function it_sets_decoded_value_in_request_when_passthrough_enabled(Request $request, ParameterBag $attributes)
+    {
+        $this->beConstructedWith($this->sqids, true, false, Sqids::DEFAULT_ALPHABET);
+
+        $encoded = $this->sqids->encode([42]);
+        $request->attributes = $attributes;
+        $attributes->get('_sqid_id')->willReturn($encoded);
+        $attributes->has('sqids_prevent_alias')->willReturn(false);
+        $attributes->has('sqid')->willReturn(false);
+        $attributes->has('id')->willReturn(false);
+
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $attributes->set('id', 42)->shouldBeCalled();
+        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
+    }
+
+    // Edge cases
+
+    function it_resolves_with_value_equals_0()
+    {
+        $request = new Request([], [], ['_sqid_id' => $this->sqids->encode([0])]);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([0]);
+    }
+
+    function it_skips_when_sqid_contains_invalid_alphabet_chars()
+    {
+        $request = new Request([], [], ['_sqid_id' => '!!!']);
+        $argumentMetadata = new ArgumentMetadata('id', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
+    }
+
+    function it_skips_non_string_alias_values()
+    {
+        $request = new Request([], [], ['id' => 123]);
+        $argumentMetadata = new ArgumentMetadata('foo', 'int', false, false, null);
+
+        $this->resolve($request, $argumentMetadata)->shouldReturn([]);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,7 +43,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultFalse()
                 ->end()
                 ->booleanNode('auto_convert')
-                    ->info('If true, automatically attempts to decode all string parameters. Use "_sqid_" prefix in routing for explicit conversion.')
+                    ->info('If true, automatically attempts to decode any route parameter matching an int argument name. When false, only parameters with "_sqid_" prefix or #[Sqid] attribute are decoded.')
                     ->defaultFalse()
                 ->end()
             ->end();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -38,6 +38,14 @@ class Configuration implements ConfigurationInterface
                     ->info('A list of sqids to block')
                     ->defaultValue(null)
                 ->end()
+                ->booleanNode('passthrough')
+                    ->info('If true, sets decoded value in request attributes for the next resolver (useful for Doctrine entity conversion)')
+                    ->defaultFalse()
+                ->end()
+                ->booleanNode('auto_convert')
+                    ->info('If true, automatically attempts to decode all string parameters. Use "_sqid_" prefix in routing for explicit conversion.')
+                    ->defaultFalse()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/src/DependencyInjection/RoukmouteSqidsExtension.php
+++ b/src/DependencyInjection/RoukmouteSqidsExtension.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 class RoukmouteSqidsExtension extends ConfigurableExtension
 {
     /**
-     * @param array{alphabet: string, min_length: int, blocklist: array<int, string>|null} $mergedConfig
+     * @param array{alphabet: string, min_length: int, blocklist: array<int, string>|null, passthrough: bool, auto_convert: bool} $mergedConfig
      */
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
     {
@@ -26,5 +26,9 @@ class RoukmouteSqidsExtension extends ConfigurableExtension
             ->setArgument(1, $mergedConfig['min_length'])
             ->setArgument(2, $mergedConfig['blocklist'])
         ;
+
+        foreach (['alphabet', 'passthrough', 'auto_convert'] as $parameter) {
+            $container->setParameter('sqids.' . $parameter, $mergedConfig[$parameter]);
+        }
     }
 }

--- a/src/ValueResolver/SqidsValueResolver.php
+++ b/src/ValueResolver/SqidsValueResolver.php
@@ -45,7 +45,7 @@ class SqidsValueResolver implements ValueResolverInterface
         }
 
         /** @var int $decodedValue */
-        $decodedValue = reset($decoded);
+        $decodedValue = $decoded[0];
 
         if ($this->passthrough) {
             $request->attributes->set($name, $decodedValue);
@@ -61,7 +61,7 @@ class SqidsValueResolver implements ValueResolverInterface
      */
     private function isValidDecode(array $decoded, bool $isExplicit, string $name): bool
     {
-        if (!\is_int(reset($decoded))) {
+        if ($decoded === [] || !\is_int($decoded[0])) {
             if ($isExplicit) {
                 throw new \LogicException(sprintf('Unable to decode parameter "%s".', $name));
             }


### PR DESCRIPTION
## Summary
- Add `passthrough` config: sets decoded value in request attributes for next resolver (useful for Doctrine entity conversion)
- Add `auto_convert` config: automatically decode all string parameters
- Add prefix support: `_sqid_` prefix for explicit conversion
- Add alias support: `sqid` and `id` parameter names are automatically resolved
- Update Configuration.php with new options
- Update SqidsValueResolver with new logic
- Add comprehensive specs for all modes

## Configuration
```yaml
roukmoute_sqids:
    alphabet: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
    min_length: 0
    blocklist: null
    passthrough: false  # NEW
    auto_convert: false # NEW
```

## Usage Examples

### Prefix support
```php
// Route: /users/{_sqid_id}
public function show(int $id): Response
{
    // $id is decoded from the _sqid_id route parameter
}
```

### Alias support
```php
// Route: /users/{id} or /users/{sqid}
public function show(int $userId): Response
{
    // $userId is decoded from 'id' or 'sqid' route parameter
}
```

### Auto convert mode
```yaml
roukmoute_sqids:
    auto_convert: true
```
```php
// Route: /users/{id}
public function show(int $id): Response
{
    // $id is automatically decoded if it looks like a sqid
}
```

### Passthrough mode (for Doctrine)
```yaml
roukmoute_sqids:
    passthrough: true
```
```php
// Route: /users/{id}
public function show(User $user): Response
{
    // The sqid is decoded and set in request attributes,
    // then Doctrine's ParamConverter resolves the User entity
}
```

Closes #3