### PR TITLE
Symfony 8 compat: Add return type to `loadInternal` method

### DIFF
--- a/src/DependencyInjection/RoukmouteSqidsExtension.php
+++ b/src/DependencyInjection/RoukmouteSqidsExtension.php
@@ -15,7 +15,7 @@ class RoukmouteSqidsExtension extends ConfigurableExtension
     /**
      * @param array{alphabet: string, min_length: int, blocklist: array<int, string>|null, passthrough: bool, auto_convert: bool} $mergedConfig
      */
-    protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
         $loader = new Loader\PhpFileLoader($container, new FileLocator(__DIR__ . '/../../Resources/config'));
         $loader->load('services.php');


### PR DESCRIPTION
Added return type declaration for `loadInternal` method, without it, the bundle is not Symfony 8+ compatible.